### PR TITLE
removed EventEmitter declaration - was never used

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var React = require('react-native');
 var { DeviceEventEmitter } = React;
-var EventEmitter = require('EventEmitter');
 
 var NotificationModule = require('react-native').NativeModules.NotificationModule;
 


### PR DESCRIPTION
Declaration of variable EventEmitter lead to a red screen when trying to launch the app with an iPhone.
Since it wasn't used, removed it.
Solve Issue #6 