### PR TITLE
match the latest published npm versions of react-native-gcm-android

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   ],
   "peerDependencies": {
     "react-native": ">=0.15.0",
-    "react-native-gcm-android": "^0.1.9"
+    "react-native-gcm-android": "^0.2.0"
   }
 }


### PR DESCRIPTION
Currently the latest published version of `react-native-gcm-android` is 0.2.0, using caret range `^0.1.9` will not meet the dependency.