### PR TITLE
Remove gcm peerDependency altogether

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "notification"
   ],
   "peerDependencies": {
-    "react-native": ">=0.15.0",
-    "react-native-gcm-android": "^0.2.0"
+    "react-native": ">=0.15.0"
   }
 }


### PR DESCRIPTION
The original gcm package is not maintained, there are lots of forks that do not fit into `^0.2.0` specifier.
README says clearly you should use it if you want to do GCM things, so no need to put it into package.json.
Moreover, maybe someone just wants to create a notification without tying it to gcm.