### PR TITLE
Play custom sound when the sound is set for local notification

### DIFF
--- a/android/src/main/java/io/neson/react-native/notification/Notification.java
+++ b/android/src/main/java/io/neson/react-native/notification/Notification.java
@@ -228,6 +228,10 @@ public class Notification {
             notificationBuilder.setLocalOnly(attributes.localOnly);
         }
 
+        if (attributes.sound != null) {
+            notificationBuilder.setSound(Uri.parse(attributes.sound));
+        }
+
         return notificationBuilder.build();
     }
 

--- a/android/src/main/java/io/neson/react-native/notification/Notification.java
+++ b/android/src/main/java/io/neson/react-native/notification/Notification.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.support.annotation.Nullable;
+import android.net.Uri;
 
 import java.lang.System;
 import java.util.HashMap;


### PR DESCRIPTION
As is, the custom sound is not played when the local notification is displayed because the sound is not set on the notification. [#37](https://github.com/Neson/react-native-system-notification/issues/37)