### PR TITLE
NotificationPackage has no constructor parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ public class MainActivity extends ReactActivity {
     @Override
     protected List<ReactPackage> getPackages() {
         return Arrays.<ReactPackage>asList(
-            new NotificationPackage(this)                  // <- Add this line
+            new NotificationPackage()                  // <- Add this line
         );
     }
 


### PR DESCRIPTION
It leads to an error if i pass this (current activity) to the NotificationPackage constructor. Removing »this«, it works like a charme!