### PR TITLE
Remove Play Services version requirement

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,6 +21,6 @@ dependencies {
     compile 'com.google.code.gson:gson:2.3.+'
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.android.support:support-annotations:+'
-    compile 'com.google.android.gms:play-services-gcm:8.1.0+'
+    compile 'com.google.android.gms:play-services-gcm:+'
     compile files('libs/js.jar')
 }


### PR DESCRIPTION
When another dependency require 'com.google.android.gms:play-services-gcm', the versions mismatch and the build fail.

Solve this issue:
https://github.com/Neson/react-native-system-notification/issues/48